### PR TITLE
Added more languages and a Norwegian translation

### DIFF
--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,0 +1,12 @@
+<resources>
+    <string name="xposed_description">Bestem språket for hver individuelle app</string>
+
+    <string name="loading_apps">Laster inn apper&#8230;</string>
+    <string name="action_search">Søk</string>
+    <string name="action_language">Språk</string>
+    <string name="choose_languages">Velg språkalternativer</string>
+    <string name="choose_languages_save">Lagre</string>
+    <string name="choose_languages_cancel">Lukk</string>
+    <string name="show_system_apps">Vis systemapper</string>
+    <string name="show_only_modified_apps">Vis bare justerte apper</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,9 +14,11 @@
     <string-array name="locales" translatable="false">
         <item>ar-EG</item>
         <item>ar-IL</item>
+        <item>be</item>
         <item>bg</item>
         <item>ca</item>
         <item>cs</item>
+        <item>cy</item>
         <item>da-DK</item>
         <item>de-AT</item>
         <item>de-CH</item>
@@ -35,7 +37,11 @@
         <item>eo</item>
         <item>es-ES</item>
         <item>es-US</item>
+        <item>et</item>
+        <item>eu</item>
+        <item>fa</item>
         <item>fi</item>
+        <item>fo</item>
         <item>fr-BE</item>
         <item>fr-CA</item>
         <item>fr-CH</item>
@@ -44,13 +50,22 @@
         <item>hi</item>
         <item>hr</item>
         <item>hu</item>
+        <item>id</item>
+        <item>is</item>
         <item>it-CH</item>
         <item>it-IT</item>
         <item>ja</item>
+        <item>kk</item>
+        <item>kl</item>
         <item>ko</item>
+        <item>lb</item>
         <item>lt</item>
         <item>lv</item>
+        <item>mn</item>
+        <item>ms</item>
         <item>nb</item>
+        <item>nn</item>
+        <item>no</item>
         <item>nl-BE</item>
         <item>nl-NL</item>
         <item>pl</item>
@@ -60,8 +75,10 @@
         <item>ru</item>
         <item>sk</item>
         <item>sl</item>
+        <item>sq</item>
         <item>sr</item>
         <item>sv</item>
+        <item>ta</item>
         <item>th</item>
         <item>tr</item>
         <item>uk</item>


### PR DESCRIPTION
Hello. I decided to add some more languages to the language selection screens, and to add a Norwegian translation for the app as well.

There is a bit of a story behind the ISO additions. You see, back when I worked on the Norwegian Bokmål translation of Barcode Scanner (the one by ZXing), there were some confusion over how to ISO-code its language file, and it was realised a tad too late that the "no" ISO code had been deprecated on Android for some years now in favour of (primarily) "nb", and that the Norwegian translation did not show up on newer Android phones. And since Barcode Scanner isn't updated very often, I came across this app (App Locale 2) as an attempt to uncover and properly show Barcode Scanner's Norwegian translation on my phone... which currently isn't possible, as there is no "no" tag (which'd equate to "Norwegian", "Norsk", "Norwegian (deprecated)", or something of some sort) that can be selected in App Locale 2 at the time of writing. So now I've tried to add it here as a pull request.

While I was at it anyway, I figured that I could just as well add some other Nordic languages (Nynorsk, Faroese, Greenlandic, Estonian), and various languages from around the world that I feel pretty certain that someone have made an app in at some point in time (Belarusian, Welsh, Basque, Persian, Indonesian, Kazakh, Luxembourgish, Mongolian, Malay, Albanian, and Tamil).

Plus I made a translation of the Values file to Norwegian Bokmål, so that I can use App Locale 2 in my mother tongue.

Any questions?